### PR TITLE
Add option to update main record

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1,7 +1,9 @@
+
 logfile: /etc/digitalocean-dns-updater/updater.log
 token: tokenoauthapi
 domain: contoso.com
 interval: 60
+update_main_record: true
 records:
   - type: MX
     priority: 1


### PR DESCRIPTION
This allows ignoring the main DNS @ record and instead uses the first record in the list to check if the record needs to be updated.

In my case, I want to only update a subdomain, not the main `@` record. 